### PR TITLE
Remove the raise to fix the problem

### DIFF
--- a/start.rb
+++ b/start.rb
@@ -2,6 +2,6 @@
 
 puts "Starting..."
 
-raise RuntimeError, "Don't start! It will explode!"
+
 
 puts "Finished loading 100%"

--- a/start.rb
+++ b/start.rb
@@ -3,5 +3,4 @@
 puts "Starting..."
 
 
-
 puts "Finished loading 100%"


### PR DESCRIPTION
I removed the raise from the script so it should work great now! :sparkles: #197 

Closes #197 

```
$ ruby start.rb
Starting...
Finished loading 100%

```