### PR TITLE
Remove unnecessary RuntimeError

### DIFF
--- a/start.rb
+++ b/start.rb
@@ -2,6 +2,5 @@
 
 puts "Starting..."
 
-raise RuntimeError, "Don't start! It will explode!"
 
 puts "Finished loading 100%"


### PR DESCRIPTION
`raise` created an unnecessary RuntimeError.  Removed `raise`

Closes #276 