### PR TITLE
Remove raise error from start.rb

### DIFF
--- a/start.rb
+++ b/start.rb
@@ -2,6 +2,4 @@
 
 puts "Starting..."
 
-raise RuntimeError, "Don't start! It will explode!"
-
 puts "Finished loading 100%"


### PR DESCRIPTION
I removed the script that raises RuntimeError that was causing the error. #489 

Closes #489 